### PR TITLE
Fix issue with IgnoreResourceNotFound when running under Spring Boot.

### DIFF
--- a/src/main/java/com/capgemini/archaius/spring/ArchaiusSpringPropertyPlaceholderSupport.java
+++ b/src/main/java/com/capgemini/archaius/spring/ArchaiusSpringPropertyPlaceholderSupport.java
@@ -47,15 +47,10 @@ class ArchaiusSpringPropertyPlaceholderSupport {
         for (int i = locations.length -1 ; i >= 0 ; i--) {
             try {
                 config.addConfiguration(new PropertiesConfiguration(locations[i].getURL()));
-            } catch (IOException ex) {
+            } catch (IOException | ConfigurationException ex) {
                 if (ignoreResourceNotFound != true) {
                     LOGGER.error("IOException thrown when adding a configuration location.", ex);
                     throw ex;
-                }
-            } catch (ConfigurationException ce) {
-                if (ignoreResourceNotFound != true) {
-                    LOGGER.error("ConfigurationException thrown when adding a configuration location.", ce);
-                    throw ce;
                 }
             }
         }


### PR DESCRIPTION
Fix issue when running with Spring Boot, IgnoreResourceNotFound was not working as an Apache Commons  exception was being thrown not an IOException.
