### PR TITLE
Fix for ignoreResourceNotFound = true' does not honour when use invalid file  location

### DIFF
--- a/src/main/java/com/capgemini/archaius/spring/ArchaiusBridgePropertyPlaceholderConfigurer.java
+++ b/src/main/java/com/capgemini/archaius/spring/ArchaiusBridgePropertyPlaceholderConfigurer.java
@@ -40,7 +40,7 @@ public class ArchaiusBridgePropertyPlaceholderConfigurer extends BridgePropertyP
     private static final Logger LOGGER = LoggerFactory.getLogger(ArchaiusBridgePropertyPlaceholderConfigurer.class);
     private final transient ArchaiusSpringPropertyPlaceholderSupport propertyPlaceholderSupport
             = new ArchaiusSpringPropertyPlaceholderSupport();
-    private transient boolean ignoreResourceNotFound;
+    private transient boolean ignoreResourceNotFound=false;
     private transient boolean ignoreDeletesFromSource = true;
     private transient Map<String, String> jdbcConnectionDetailMap = null;
 

--- a/src/main/java/com/capgemini/archaius/spring/ArchaiusSpringPropertyPlaceholderSupport.java
+++ b/src/main/java/com/capgemini/archaius/spring/ArchaiusSpringPropertyPlaceholderSupport.java
@@ -91,7 +91,7 @@ class ArchaiusSpringPropertyPlaceholderSupport {
                 config.addConfiguration(new DynamicURLConfiguration(
                         initialDelayMillis, delayMillis, ignoreDeletesFromSource, locationURL
                 ));
-            } catch (IOException ex) {
+            } catch (Exception ex) {
                 if (!ignoreResourceNotFound) {
                     LOGGER.error("Exception thrown when adding a configuration location.", ex);
                     throw ex;
@@ -166,14 +166,14 @@ class ArchaiusSpringPropertyPlaceholderSupport {
                 conComConfiguration.addConfiguration(new DynamicURLConfiguration(
                         initialDelayMillis, delayMillis,
                         ignoreDeletesFromSource, locationURL));
-            } catch (IOException ex) {
+            } catch (Exception ex) {
                 if (!ignoreResourceNotFound) {
                     LOGGER.error(
                             "Exception thrown when adding a configuration location.",
                             ex);
                     throw ex;
                 }
-            }
+            } 
         }
 
         DynamicPropertyFactory.initWithConfigurationSource(conComConfiguration);

--- a/src/test/resources/spring/jdbc/archaiusJdbcPropertiesLoadingTest.xml
+++ b/src/test/resources/spring/jdbc/archaiusJdbcPropertiesLoadingTest.xml
@@ -16,6 +16,9 @@
         <property name="locations">
             <list>
                 <value>classpath:properties/archaiusPropertyOverloading.properties</value>
+                <value>classpath:/META-INF/system.properties</value>
+                <value>classpath:/META-INF/file-not-there.properties</value>
+                <value>file:/test/file.properties</value>
             </list>
         </property>
     </bean>


### PR DESCRIPTION
Fix for issue 'ignoreResourceNotFound = true' does not honour when you use invalid 'file' location.
