### PR TITLE
Allow duplicate placeholder configs if desired

### DIFF
--- a/src/main/java/com/capgemini/archaius/spring/ArchaiusBridgePropertyPlaceholderConfigurer.java
+++ b/src/main/java/com/capgemini/archaius/spring/ArchaiusBridgePropertyPlaceholderConfigurer.java
@@ -39,6 +39,7 @@ public class ArchaiusBridgePropertyPlaceholderConfigurer extends BridgePropertyP
     private transient int delayMillis = DEFAULT_DELAY;
     private transient boolean ignoreResourceNotFound = false;
     private transient boolean ignoreDeletesFromSource = true;
+    private transient boolean allowMultiplePlaceholders = false;
     
     private final transient ArchaiusSpringPropertyPlaceholderSupport propertyPlaceholderSupport
             = new ArchaiusSpringPropertyPlaceholderSupport();
@@ -78,6 +79,16 @@ public class ArchaiusBridgePropertyPlaceholderConfigurer extends BridgePropertyP
         this.ignoreDeletesFromSource = ignoreDeletesFromSource;
     }
 
+    /**
+     * Should the system allow duplicate beans and just read from the initial one? 
+     * This helps in the case where you want to define beans in both a parent web application
+     * context and a servlet-specific context
+     */
+    public void setAllowMultiplePlaceholders(boolean allowMultiplePlaceholders) {
+        this.allowMultiplePlaceholders = allowMultiplePlaceholders;
+    }
+    
+    
     @Override
     protected String resolvePlaceholder(String placeholder, Properties props, int systemPropertiesMode) {
         return propertyPlaceholderSupport.resolvePlaceholder(placeholder, props, systemPropertiesMode);
@@ -101,7 +112,8 @@ public class ArchaiusBridgePropertyPlaceholderConfigurer extends BridgePropertyP
     @Override
     public void setLocations(Resource[] locations) {
         try {       
-            Map parameterMap = propertyPlaceholderSupport.getParameterMap(delayMillis, initialDelayMillis, ignoreDeletesFromSource, ignoreResourceNotFound);
+            Map parameterMap = propertyPlaceholderSupport.getParameterMap(delayMillis, initialDelayMillis, ignoreDeletesFromSource, 
+                                                                          ignoreResourceNotFound, allowMultiplePlaceholders);
             
             // If there is not also a JDBC properties location to consider
             if (jdbcConnectionDetailMap == null) {

--- a/src/main/java/com/capgemini/archaius/spring/ArchaiusPropertyPlaceholderConfigurer.java
+++ b/src/main/java/com/capgemini/archaius/spring/ArchaiusPropertyPlaceholderConfigurer.java
@@ -39,6 +39,7 @@ public class ArchaiusPropertyPlaceholderConfigurer extends PropertyPlaceholderCo
     private transient int delayMillis = DEFAULT_DELAY;
     private transient boolean ignoreResourceNotFound = false;
     private transient boolean ignoreDeletesFromSource = true;
+    private transient boolean allowMultiplePlaceholders = false;
 
     private final transient ArchaiusSpringPropertyPlaceholderSupport propertyPlaceholderSupport 
             = new ArchaiusSpringPropertyPlaceholderSupport();
@@ -72,6 +73,15 @@ public class ArchaiusPropertyPlaceholderConfigurer extends PropertyPlaceholderCo
         this.ignoreDeletesFromSource = ignoreDeletesFromSource;
     }
 
+    /**
+     * Should the system allow duplicate beans and just read from the initial one? 
+     * This helps in the case where you want to define beans in both a parent web application
+     * context and a servlet-specific context
+     */
+    public void setAllowMultiplePlaceholders(boolean allowMultiplePlaceholders) {
+        this.allowMultiplePlaceholders = allowMultiplePlaceholders;
+    }
+    
     @Override
     public void setIgnoreResourceNotFound(boolean setting) {
         ignoreResourceNotFound = setting;
@@ -101,7 +111,8 @@ public class ArchaiusPropertyPlaceholderConfigurer extends PropertyPlaceholderCo
     @Override
     public void setLocations(Resource[] locations) {
         try {        
-            Map parameterMap = propertyPlaceholderSupport.getParameterMap(delayMillis, initialDelayMillis, ignoreDeletesFromSource, ignoreResourceNotFound);
+            Map parameterMap = propertyPlaceholderSupport.getParameterMap(delayMillis, initialDelayMillis, ignoreDeletesFromSource, 
+                                                                          ignoreResourceNotFound, allowMultiplePlaceholders);
             
             // If there is not also a JDBC properties location to consider
             if (jdbcConnectionDetailMap == null) {

--- a/src/main/java/com/capgemini/archaius/spring/constants/JdbcContants.java
+++ b/src/main/java/com/capgemini/archaius/spring/constants/JdbcContants.java
@@ -22,4 +22,5 @@ public final class JdbcContants {
     public static final String IGNORE_DELETE_FROM_SOURCE = "ignoreDeletesFromSource";
     public static final String INITIAL_DELAY_MILLIS = "initialDelayMillis";
     public static final String DELAY_MILLIS = "delayMillis";
+    public static final String ALLOW_MULTIPLE_PLACEHOLDERS = "allowMultiplePlaceholders";
 }

--- a/src/test/groovy/com/capgemini/archaius/spring/SpringDuplicateDefinitionIsNotOkSpec.groovy
+++ b/src/test/groovy/com/capgemini/archaius/spring/SpringDuplicateDefinitionIsNotOkSpec.groovy
@@ -1,0 +1,23 @@
+package com.capgemini.archaius.spring
+
+import org.springframework.beans.factory.BeanCreationException
+import org.springframework.context.support.ClassPathXmlApplicationContext
+import org.springframework.test.context.ActiveProfiles
+import spock.lang.Specification
+
+/**
+ * @author: Scott Rankin
+ * @version: 1.0
+ */
+@ActiveProfiles('default')
+class SpringDuplicateDefinitionIsNotOkSpec extends Specification {
+
+    def "missing spring properties files is not ok if IgnoreResourceNotFound property set to false" () {
+        when:
+            ctx = new ClassPathXmlApplicationContext('spring/springDuplicateDefinitionIsNotOkTest.xml')
+        then:
+            BeanCreationException bce = thrown()
+            bce.cause.message == 'Failed properties: Property \'locations\' threw exception; nested exception is ' +
+                    'java.lang.IllegalStateException: Archaius is already configured with a property source/sources.'
+    }
+}

--- a/src/test/groovy/com/capgemini/archaius/spring/SpringDuplicateDefinitionIsOkSpec.groovy
+++ b/src/test/groovy/com/capgemini/archaius/spring/SpringDuplicateDefinitionIsOkSpec.groovy
@@ -1,0 +1,33 @@
+package com.capgemini.archaius.spring
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.ActiveProfiles
+import spock.lang.Specification
+
+/**
+ * @author: Scott Rankin
+ * @version: 1.0
+ */
+@ActiveProfiles('default')
+@ContextConfiguration(locations = 'classpath:spring/springDuplicateDefinitionIsOkTest.xml')
+class SpringDuplicateDefinitionIsOkSpec extends Specification {
+    @Autowired
+    @Qualifier('configOne')
+    private final ArchaiusPropertyPlaceholderConfigurer configOne
+
+    @Autowired
+    @Qualifier('configTwo')
+    private final ArchaiusPropertyPlaceholderConfigurer configTwo
+
+    def 'Duplicate definitions OK and config one loads properties' () {
+        expect:
+            configOne.resolvePlaceholder('var2', null, 0) == 'MY SECOND VAR'
+    }
+
+    def 'Duplicate definitions OK and config two does not load its specified properties' () {
+        expect:
+            configTwo.resolvePlaceholder('var3', null, 0) == null
+    }
+}

--- a/src/test/resources/META-INF/even-more-system.properties
+++ b/src/test/resources/META-INF/even-more-system.properties
@@ -1,4 +1,4 @@
 var1=${mvn.var1}
 var2=MY SECOND VAR (THIS ONE WINS)
-
+var3=THIS IS THE THIRD
 

--- a/src/test/resources/spring/springDuplicateDefinitionIsNotOkTest.xml
+++ b/src/test/resources/spring/springDuplicateDefinitionIsNotOkTest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <!-- Config loading via Spring-Archaius-->
+    <bean class="com.capgemini.archaius.spring.ArchaiusPropertyPlaceholderConfigurer">
+        <property name="locations">
+            <list>
+                <value>classpath:/META-INF/system.properties</value>
+                <value>classpath:/META-INF/even-more-system.properties</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean class="com.capgemini.archaius.spring.ArchaiusPropertyPlaceholderConfigurer">
+        <property name="locations">
+            <list>
+                <value>classpath:/META-INF/system.properties</value>
+                <value>classpath:/META-INF/even-more-system.properties</value>
+            </list>
+        </property>
+    </bean>
+    
+</beans>

--- a/src/test/resources/spring/springDuplicateDefinitionIsOkTest.xml
+++ b/src/test/resources/spring/springDuplicateDefinitionIsOkTest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <!-- Config loading via Spring-Archaius-->
+    <bean class="com.capgemini.archaius.spring.ArchaiusPropertyPlaceholderConfigurer"
+          id="configOne">
+        <property name="allowMultiplePlaceholders" value="true"/>
+        <property name="locations">
+            <list>
+                <value>classpath:/META-INF/system.properties</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean class="com.capgemini.archaius.spring.ArchaiusPropertyPlaceholderConfigurer"
+          id="configTwo">
+        <property name="allowMultiplePlaceholders" value="true"/>
+        <property name="locations">
+            <list>
+                <value>classpath:/META-INF/even-more-system.properties</value> 
+            </list>
+        </property>
+    </bean>
+    
+</beans>


### PR DESCRIPTION
Hi all,

I was very excited to see this project  - we're facing the same architectural challenges that you are.  One thing, though, is that in Spring MVC web applications, there is often a need to have PropertyPlaceholderConfigurers in both the root application context and the dispatcher servlet application context (because Bean Post Processors can't cross parent-child context boundaries).  

This change allows the user to specify that they're ok if multiple placeholder configurers register, and will just use the config of the first one that makes it.  

I'm open to feedback, but this helped us tremendously. 

Thanks!
Scott