### PR TITLE
Remove test config from published jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,10 +155,6 @@
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
             </resource>
-            <resource>
-                <directory>src/test/resources</directory>
-                <filtering>true</filtering>
-            </resource>
         </resources>
 
         <plugins>


### PR DESCRIPTION
Removed the maven config which meant all the test config files were ending up in the published JAR and causing untold havoc in spring-boot projects.